### PR TITLE
Capitalise URL in app name.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ require "action_controller/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module UrlArbiter
+module URLArbiter
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/initializers/acronym.rb
+++ b/config/initializers/acronym.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'URL'
+end


### PR DESCRIPTION
As per styleguide: https://github.com/alphagov/styleguides/blob/master/ruby.md#naming
