### PR TITLE
Change how db auth is done for dev and test.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,9 +6,9 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
-  username: url-arbiter
-  password: url-arbiter
-  host: localhost
+  # Necessary to allow creating a db with different encodings.
+  # See http://www.postgresql.org/docs/9.1/static/manage-ag-templatedbs.html for details
+  template: template0
 
 development:
   <<: *default

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -5,5 +5,5 @@ export RAILS_ENV=test
 
 git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-
+bundle exec rake db:drop db:create db:schema:load
 bundle exec rake


### PR DESCRIPTION
Not specifying a username and password means we can fall back to ident
based auth.  This relies on a postgres role with createdb permissions
existing for the user running.  This has been configured on the dev VM
and on CI.

This change also updates the jenkins script to drop the database before
each run to ensure a clean state.
