### PR TITLE
Update conflict error to be on path field.

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -13,7 +13,7 @@ class ReservationsController < ApplicationController
       status_to_use = @reservation.new_record? ? :created : :ok
       @reservation.update_attributes(@request_data) or status_to_use = :unprocessable_entity
     else
-      @reservation.errors.add(:base, "is already reserved by the '#{@reservation.publishing_app}' app")
+      @reservation.errors.add(:path, "is already reserved by the '#{@reservation.publishing_app}' app")
       status_to_use = :conflict
     end
 

--- a/spec/integration/registering_path_spec.rb
+++ b/spec/integration/registering_path_spec.rb
@@ -44,7 +44,7 @@ describe "Registering a path", :type => :request do
 
       expect(response.status).to eq(409)
       data = JSON.parse(response.body)
-      expect(data["errors"]).to eq({"base" => ["is already reserved by the 'publisher' app"]})
+      expect(data["errors"]).to eq({"path" => ["is already reserved by the 'publisher' app"]})
 
       @reservation.reload
       expect(@reservation.publishing_app).to eq("publisher")


### PR DESCRIPTION
This makes it easier to consume and pass on the error in downstream
applications.
