### PR TITLE
Fix panopticon import to work authenticate.

### DIFF
--- a/config/initializers/panopticon_bearer_token.rb
+++ b/config/initializers/panopticon_bearer_token.rb
@@ -1,0 +1,4 @@
+# This file is overwritten on deploy.
+
+# In dev mode, any token will work.
+PANOPTICON_BEARER_TOKEN = "anything"

--- a/lib/panopticon_importer.rb
+++ b/lib/panopticon_importer.rb
@@ -2,6 +2,9 @@ require 'rest_client'
 require 'plek'
 
 class PanopticonImporter
+  def initialize(bearer_token)
+    @bearer_token = bearer_token
+  end
 
   def import
     puts "Importing artefacts from panopticon"
@@ -36,7 +39,11 @@ class PanopticonImporter
   end
 
   def get_page(page)
-    response = RestClient.get(artefacts_url + "?minimal=1&page=#{page}")
+    headers = {
+      "Accept" => "application/json",
+      "Authorization" => "Bearer #{@bearer_token}"
+    }
+    response = RestClient.get(artefacts_url + "?minimal=1&page=#{page}", headers)
     return JSON.parse(response.body)
   end
 

--- a/lib/tasks/reservations.rake
+++ b/lib/tasks/reservations.rake
@@ -3,6 +3,6 @@ namespace :reservations do
   desc "Seed reservations with data from Panopticon"
   task :seed_from_panopticon => :environment do
     require "panopticon_importer"
-    PanopticonImporter.new.import
+    PanopticonImporter.new(PANOPTICON_BEARER_TOKEN).import
   end
 end


### PR DESCRIPTION
This was working in dev because gds-sso was in mock mode.  In production
this failed with 401 errors.  This change updates it to send a bearer
token along with requests.

Note: depends on alphagov-deployment#725
