### PR TITLE
Handle non-ascii paths.

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -2,12 +2,12 @@ class ReservationsController < ApplicationController
   before_filter :parse_json_request, :only => [:update]
 
   def show
-    @reservation = Reservation.find_by_path!(params[:reserved_path])
+    @reservation = Reservation.find_by_path!(encoded_reserved_path)
     render :json => @reservation
   end
 
   def update
-    @reservation = Reservation.find_or_initialize_by(:path => params[:reserved_path])
+    @reservation = Reservation.find_or_initialize_by(:path => encoded_reserved_path)
 
     if @reservation.can_be_claimed_by?(@request_data["publishing_app"])
       status_to_use = @reservation.new_record? ? :created : :ok
@@ -26,5 +26,10 @@ class ReservationsController < ApplicationController
     @request_data = JSON.parse(request.body.read)
   rescue JSON::ParserError
     head :bad_request
+  end
+
+  # Rails unescapes %encoded chars for us, so we need to re-encode them to ensure consistency.
+  def encoded_reserved_path
+    URI.escape(params[:reserved_path])
   end
 end

--- a/spec/integration/registering_path_spec.rb
+++ b/spec/integration/registering_path_spec.rb
@@ -26,6 +26,20 @@ describe "Registering a path", :type => :request do
 
       expect(Reservation.find_by_path("/foo/bar")).to be_nil
     end
+
+    it "should handle non-ascii paths" do
+      # URI encoded 'foo-€45-bar'
+      put_json "/paths/foo-%E2%82%AC45-bar", {"publishing_app" => "publisher"}
+
+      expect(response.status).to eq(201)
+      data = JSON.parse(response.body)
+      expect(data["path"]).to eq("/foo-%E2%82%AC45-bar")
+      expect(data["publishing_app"]).to eq("publisher")
+
+      reservation = Reservation.find_by_path("/foo-%E2%82%AC45-bar")
+      expect(reservation).to be
+      expect(reservation.publishing_app).to eq("publisher")
+    end
   end
 
   describe "for a path that has previously been registerd" do

--- a/spec/integration/requesting_path_spec.rb
+++ b/spec/integration/requesting_path_spec.rb
@@ -20,4 +20,18 @@ describe "Requesting details of a path", :type => :request do
     get "/paths/non-existent"
     expect(response.status).to eq(404)
   end
+
+  it "should handle non-ascii paths" do
+    # URI encoded 'foo-€45-bar'
+    reservation = create(:reservation, :path => "/foo-%E2%82%AC45-bar")
+
+    get "/paths/foo-%E2%82%AC45-bar"
+
+    expect(response.status).to eq(200)
+    expect(response.content_type).to eq("application/json")
+
+    data = JSON.parse(response.body)
+    expect(data["path"]).to eq("/foo-%E2%82%AC45-bar")
+    expect(data["publishing_app"]).to eq(reservation.publishing_app)
+  end
 end


### PR DESCRIPTION
This updates the controller to handle non-ascii paths by storing their
URI encoded representation in the database.
