### PR TITLE
Change Publishing App of Finders

### DIFF
--- a/db/migrate/20150109113253_change_finder_api_reservations_to_specialist_publisher.rb
+++ b/db/migrate/20150109113253_change_finder_api_reservations_to_specialist_publisher.rb
@@ -1,0 +1,13 @@
+class ChangeFinderApiReservationsToSpecialistPublisher < ActiveRecord::Migration
+  def up
+    reservations = Reservation.where(publishing_app: "finder-api")
+    reservations.each do |r|
+      r.update_attributes(publishing_app: "specialist-publisher")
+      puts "changed publishing app for #{r.path}"
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140814080900) do
+ActiveRecord::Schema.define(version: 20150109113253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
As Finders are now published from Specialist Publisher instead of Finder API, this commit adds a migration to update that so the URLs can be taken by Specialist Publisher. This is an irreversible migration because the query to get all URLs published by Specialist Publisher includes documents and manuals.
