### PR TITLE
Change owner for /national-measurement-office

### DIFF
--- a/db/migrate/20150126111754_change_nmo_ownership.rb
+++ b/db/migrate/20150126111754_change_nmo_ownership.rb
@@ -1,0 +1,13 @@
+class ChangeNmoOwnership < ActiveRecord::Migration
+  def up
+    reservation = Reservation.where(path: '/national-measurement-office').first
+    unless reservation
+      puts "WARNING: /national-measurement-office reservation not found, skipping..."
+      return
+    end
+    reservation.update_attributes!(publishing_app: 'short-url-manager')
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150109113253) do
+ActiveRecord::Schema.define(version: 20150126111754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This is currently an organisation short url managed by router-data
(which doesn't register with url-arbiter).  This route is currently
listed as being owned by Whitehall.  The live site is serving the
redirect from router-data.

This change will allow the router-data short URLs to be imported into
short-url-manager.
