### PR TITLE
Return JSON error message for invalid JSON

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -24,8 +24,13 @@ class ReservationsController < ApplicationController
 
   def parse_json_request
     @request_data = JSON.parse(request.body.read)
-  rescue JSON::ParserError
-    head :bad_request
+  rescue JSON::ParserError => e
+    response_body = {
+      errors: {
+        request_body: ["invalid JSON: #{e.message}"]
+      }
+    }
+    render json: response_body, status: :bad_request
   end
 
   # Rails unescapes %encoded chars for us, so we need to re-encode them to ensure consistency.

--- a/spec/integration/registering_path_spec.rb
+++ b/spec/integration/registering_path_spec.rb
@@ -69,5 +69,7 @@ describe "Registering a path", :type => :request do
     put "/paths/foo", "I'm not json", "CONTENT_TYPE" => "application/json"
 
     expect(response.status).to eq(400)
+    data = JSON.parse(response.body)
+    expect(data["errors"]).to eq({ "request_body" => ["invalid JSON: 757: unexpected token at 'I'm not json'"] })
   end
 end


### PR DESCRIPTION
It seems unhelpful to return a 400 with no explanation. Let's return a message
telling them what we think they did wrong.

Whilst this could be text/plain, given that gds-api-adapters sends an Accept
header of application/json by default, the client is likely expecting a JSON
response, errors included.

I intend to apply this pattern to content-store and to publishing-api, so thoughts are welcome.
