### PR TITLE
HEAD response for internal server error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,8 @@
 class ApplicationController < ActionController::API
 
-  rescue_from ActiveRecord::RecordNotFound, :with => :error_404
+  rescue_from ActiveRecord::RecordNotFound, with: ->{ show_errors(404) }
 
-  private
-
-  def error_404
-    head 404
+  def show_errors(status_code = params[:status_code] || 500)
+    head status_code
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,9 @@ module URLArbiter
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    # sets this rails application's router as the exception handler application
+    # invoked by the ShowException middleware when an exception occurs
+    config.exceptions_app = self.routes
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,9 @@ Rails.application.routes.draw do
     end
 
     r.get "/healthcheck" => proc { [200, {}, ["OK\n"]] }
+
+    %w( 404 500 ).each do |status_code|
+      get status_code, :to => "application#show_errors", :status_code => status_code
+    end
   end
 end

--- a/spec/integration/requesting_path_spec.rb
+++ b/spec/integration/requesting_path_spec.rb
@@ -16,7 +16,6 @@ describe "Requesting details of a path", :type => :request do
   end
 
   it "returns 404 for a path that has not been reserved" do
-
     get "/paths/non-existent"
     expect(response.status).to eq(404)
   end


### PR DESCRIPTION
relates to [errbit](https://errbit.preview.alphagov.co.uk/apps/53020c2d0da11590e70000a0/problems/550fbf860da1152033002ba7).

publishing-api doesn't expect HTML responses and fails to parse HTML errors returned by Rails. in such cases, [publishing-api returns JSON decoding errors](https://github.com/alphagov/publishing-api/blob/master/urlarbiter/url_arbiter.go#L57-L59) instead of forwarding url-arbiter errors as-is. this is confusing.

this change ensures that `public/<error>.html` pages are not returned when 404 or 500 errors occur, and instead a HEAD response with an appropriate status code is returned.

i think this change can only be tested manually, because in test.rb `config.consider_all_requests_local = true` which doesn't handle errors, and instead raises them.

it uses a rails config `exceptions_app` to allow the routing middleware to handle such exceptions replacing the default middleware: `ActionDispatch::PublicExceptions.new(Rails.public_path)`

more info:
http://guides.rubyonrails.org/configuring.html#rails-general-configuration
http://stackoverflow.com/a/19279062

if we like this change, we can replicate it across applications that publishing-api collects responses from.
