### PR TITLE
Fix 500 on missing parameter

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -35,6 +35,10 @@ class ReservationsController < ApplicationController
 
   # Rails unescapes %encoded chars for us, so we need to re-encode them to ensure consistency.
   def encoded_reserved_path
-    URI.escape(params[:reserved_path])
+    URI.escape(reserved_path)
+  end
+
+  def reserved_path
+    params.fetch(:reserved_path)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
 
   with_options :format => false do |r|
     r.with_options :constraints => {:reserved_path => %r[/.*]} do |path_routes|
-      path_routes.get "/paths(*reserved_path)" => "reservations#show"
-      path_routes.put "/paths(*reserved_path)" => "reservations#update"
+      path_routes.get "/paths*reserved_path" => "reservations#show"
+      path_routes.put "/paths*reserved_path" => "reservations#update"
     end
 
     r.get "/healthcheck" => proc { [200, {}, ["OK\n"]] }


### PR DESCRIPTION
Pen testing on staging triggered a few thousand 500 errors when making requests to `/paths`. This change means a request to `/paths` will get a 400 Bad Request response.
