### PR TITLE
Accept root path `/` for reservation.

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -39,6 +39,6 @@ class ReservationsController < ApplicationController
   end
 
   def reserved_path
-    params.fetch(:reserved_path)
+    "/#{params[:reserved_path]}"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,8 @@
 Rails.application.routes.draw do
-
-  with_options :format => false do |r|
-    r.with_options :constraints => {:reserved_path => %r[/.*]} do |path_routes|
-      path_routes.get "/paths*reserved_path" => "reservations#show"
-      path_routes.put "/paths*reserved_path" => "reservations#update"
-    end
-
-    r.get "/healthcheck" => proc { [200, {}, ["OK\n"]] }
+  scope format: false do |r|
+    get "/paths(/*reserved_path)", to: "reservations#show"
+    put "/paths(/*reserved_path)", to: "reservations#update"
   end
+
+  get "/healthcheck" => proc { [200, {}, ["OK\n"]] }
 end

--- a/spec/routing/reservation_routing_spec.rb
+++ b/spec/routing/reservation_routing_spec.rb
@@ -6,13 +6,32 @@ describe "routing of reservation requests", :type => :routing do
       expect(:put => "/paths/foo/bar").to route_to({
         :controller => "reservations",
         :action => "update",
-        :reserved_path => "/foo/bar",
+        :reserved_path => "foo/bar",
       })
     end
 
     it "should not match a reserved_path without a leading /" do
       expect(:put => "/pathsfoo").not_to be_routable
     end
+
+    it "should match the root path" do
+      expect(put: "/paths/").to route_to({
+        controller: "reservations",
+        action: "update",
+      })
+    end
+  end
+
+  context "GET route" do
+    it "should not match a reserved_path without a leading /" do
+      expect(get: "/pathsfoo").not_to be_routable
+    end
+
+    it "should match the root path" do
+      expect(get: "/paths/").to route_to(
+        controller: "reservations",
+        action: "show",
+      )
+    end
   end
 end
-


### PR DESCRIPTION
Also changes the routing to be compatible with
newer versions of Rails.

Needed for https://trello.com/c/blLdEZN5/292-make-apps-register-special-routes-on-deploy
