### PR TITLE
Change owner of /part-year-profit-tax-credits

### DIFF
--- a/db/migrate/20150928160448_change_owner_of_reservation_for_part_year_profit_tax_credits.rb
+++ b/db/migrate/20150928160448_change_owner_of_reservation_for_part_year_profit_tax_credits.rb
@@ -1,0 +1,14 @@
+class ChangeOwnerOfReservationForPartYearProfitTaxCredits < ActiveRecord::Migration
+  def up
+    path = '/part-year-profit-tax-credits'
+    reservation = Reservation.where(path: path).first
+    unless reservation
+      puts "WARNING: #{path} reservation not found, skipping..."
+      return
+    end
+    reservation.update_attributes!(publishing_app: 'smartanswers')
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150126111754) do
+ActiveRecord::Schema.define(version: 20150928160448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This path currently redirects to /end-tax-credits-claim/self-employed. This
redirect was put in place until we were ready to deploy a new Smart Answer at
this path. The new Smart Answer is now ready so we need to "claim" this path.

@alext said that the existing redirect was created by 'short-url-manager' and
that we need to change the owner in url-arbiter to 'smartanswers'.

This migration follows the pattern of a similar migration added in
84ad8957709892d7dcb24459b15fba2f4a590da5.
